### PR TITLE
Fix checking for files in the output directory when it doesn't exist

### DIFF
--- a/rubem/configuration/output_data_directory.py
+++ b/rubem/configuration/output_data_directory.py
@@ -29,13 +29,13 @@ class OutputDataDirectory:
                 self.logger.error("Failed to create output directory: %s", e)
                 raise
 
+        if os.listdir(self.path):
+            self.logger.warning("There is data in the output directory: %s", self.path)
+
     def __validate_directories(self) -> None:
         if os.path.isfile(self.path):
             self.logger.error("Output path is not a directory: %s", self.path)
             raise NotADirectoryError(f"{self.path} is not a directory")
-
-        if os.listdir(self.path):
-            self.logger.warning("There is data in the output directory: %s", self.path)
 
     def __str__(self) -> str:
         return f"{self.path}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the _Title_ above. -->

### Checklist
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] ~~Added **tests** for changed code.~~
- [ ] ~~Updated **documentation** for changed code.~~

### Description
<!-- Describe your changes in detail. -->

- Moves file listing in the repository to after successful creation of the directory when it does not exist.

### Related Issue
<!-- This project only accepts pull requests related to open issues. If suggesting a new feature or change, please discuss it in an issue first. -->  
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. --> 

- Resolve #146.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here. -->

- See #146.

### How has this been tested
<!-- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to. See how your change affects other areas of the code, etc. -->

1. Configure a simulation to use an output directory (valid path) that does not exist;
2. Run the simulation;
3. Verify that the output directory was created and the files resulting from the simulation are present.

### Screenshots
<!-- Only if appropriate -->

- N/A
