### PR TITLE
Improve handling of file paths for absolute paths internally

### DIFF
--- a/rubem/configuration/app_settings.py
+++ b/rubem/configuration/app_settings.py
@@ -13,11 +13,15 @@ class AppSettings:
 
     __instance = None
     __default_appsettings_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-    __default_appsettings_file = os.path.join(__default_appsettings_dir, "appsettings.json")
+    __default_appsettings_file = os.path.abspath(
+        os.path.join(__default_appsettings_dir, "appsettings.json")
+    )
 
     if "PYTHON_ENVIRONMENT" in os.environ and os.environ["PYTHON_ENVIRONMENT"]:
         custom_env_settings = f"appsettings.{os.environ['PYTHON_ENVIRONMENT']}.json"
-        custom_env_settings_path = os.path.join(__default_appsettings_dir, custom_env_settings)
+        custom_env_settings_path = os.path.abspath(
+            os.path.join(__default_appsettings_dir, custom_env_settings)
+        )
         if (
             os.path.isfile(custom_env_settings_path)
             and os.path.getsize(custom_env_settings_path) > 0
@@ -58,7 +62,7 @@ class AppSettings:
         """
 
         if app_settings_file_path:
-            app_settings_file_path_str = str(app_settings_file_path)
+            app_settings_file_path_str = os.path.abspath(app_settings_file_path)
         else:
             app_settings_file_path_str = self.__default_appsettings_file
 

--- a/rubem/configuration/input_raster_series.py
+++ b/rubem/configuration/input_raster_series.py
@@ -89,13 +89,19 @@ class InputRasterSeries:
         else:
             self.logger.warning("Input data directories validation is disabled.")
 
-        self.etp = os.path.join(str(self.__etp_dir_path), self.__etp_filename_prefix)
-        self.precipitation = os.path.join(
-            str(self.__precipitation_dir_path), self.__precipitation_filename_prefix
+        self.etp = os.path.abspath(
+            os.path.join(str(self.__etp_dir_path), self.__etp_filename_prefix)
         )
-        self.ndvi = os.path.join(str(self.__ndvi_dir_path), self.__ndvi_filename_prefix)
-        self.kp = os.path.join(str(self.__kp_dir_path), self.__kp_filename_prefix)
-        self.landuse = os.path.join(str(self.__landuse_dir_path), self.__landuse_filename_prefix)
+        self.precipitation = os.path.abspath(
+            os.path.join(str(self.__precipitation_dir_path), self.__precipitation_filename_prefix)
+        )
+        self.ndvi = os.path.abspath(
+            os.path.join(str(self.__ndvi_dir_path), self.__ndvi_filename_prefix)
+        )
+        self.kp = os.path.abspath(os.path.join(str(self.__kp_dir_path), self.__kp_filename_prefix))
+        self.landuse = os.path.abspath(
+            os.path.join(str(self.__landuse_dir_path), self.__landuse_filename_prefix)
+        )
 
     def __validate_directories(self) -> None:
         directories = [

--- a/rubem/file/_file_convertions.py
+++ b/rubem/file/_file_convertions.py
@@ -31,9 +31,9 @@ def tss2csv(tss_dir_path: str, cols_names: list[str], should_delete_src_tss: boo
     header = ["0"]
     header.extend(cols_names)
 
-    for tss_file in glob.glob(os.path.join(tss_dir_path, "*.tss")):
-        dst_file_path = os.path.join(
-            os.path.dirname(tss_file), f"{os.path.splitext(tss_file)[0]}.csv"
+    for tss_file in glob.glob(os.path.abspath(os.path.join(tss_dir_path, "*.tss"))):
+        dst_file_path = os.path.abspath(
+            os.path.join(os.path.dirname(tss_file), f"{os.path.splitext(tss_file)[0]}.csv")
         )
         with open(file=tss_file, mode="r", encoding="utf8") as f:
             lines = f.readlines()

--- a/rubem/file/_file_generators.py
+++ b/rubem/file/_file_generators.py
@@ -68,12 +68,14 @@ def __report(
     no_data_value: float = -9999,
 ):
     if timestep:
-        out_tif = os.path.join(
-            str(outpath),
-            f"{name}{str(timestep).zfill(10 - len(name))}.{extension}",
+        out_tif = os.path.abspath(
+            os.path.join(
+                str(outpath),
+                f"{name}{str(timestep).zfill(10 - len(name))}.{extension}",
+            )
         )
     else:
-        out_tif = os.path.join(str(outpath), f"{name}.{extension}")
+        out_tif = os.path.abspath(os.path.join(str(outpath), f"{name}.{extension}"))
 
     gdal.UseExceptions()
     gdal.AllRegister()


### PR DESCRIPTION
### Checklist
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] ~~Added **tests** for changed code.~~
- [ ] ~~Updated **documentation** for changed code.~~

### Description
<!-- Describe your changes in detail. -->

- The changes involve modifying the code to use `os.path.abspath()` alongside `os.path.join()` to construct paths within the application, ensuring consistency and compatibility across different platforms.

### Related Issue
<!-- This project only accepts pull requests related to open issues. If suggesting a new feature or change, please discuss it in an issue first. -->  
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. --> 

- Resolve #186.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here. -->

- This change is necessary to enhance the robustness and portability of the application by preventing path-related errors, especially when executed on different operating systems;
- See #186.

### How has this been tested
<!-- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to. See how your change affects other areas of the code, etc. -->

- Testing was conducted by running the application on multiple platforms, including Windows, and Linux, to ensure consistent behavior.

### Screenshots
<!-- Only if appropriate -->

- N/A