### PR TITLE
Update hash computation command in `build-release.yml`

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Compute Hash
         run: |
           cd ./dist/
-          sha512sum rubem-${{ github.ref_name }}-${{ matrix.os }}-x86_64.zip > rubem-${{ github.ref_name }}-${{ matrix.os }}-x86_64.zip.sha512
+          shasum -a 512 rubem-${{ github.ref_name }}-${{ matrix.os }}-x86_64.zip > rubem-${{ github.ref_name }}-${{ matrix.os }}-x86_64.zip.sha512
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
macOS doesn't have `sha512sum`

<!-- Provide a general summary of your changes in the _Title_ above. -->

### Checklist
- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

### Description
<!-- Describe your changes in detail. -->

- TBF

### Related Issue
<!-- This project only accepts pull requests related to open issues. If suggesting a new feature or change, please discuss it in an issue first. -->  
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. --> 

- Resolve #???;

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here. -->

- TBF

### How has this been tested
<!-- Please describe in detail how you tested your changes. Include details of your testing environment, and the tests you ran to. See how your change affects other areas of the code, etc. -->

- TBF

### Screenshots
<!-- Only if appropriate -->

- N/A
